### PR TITLE
fix so if gitTagVersion is false we dont tag a version

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -62,7 +62,7 @@ module.exports = async (newversion, opts) => {
 
   // - check if git dir is clean
   // returns false if we should not keep doing git stuff
-  const doGit = isGitDir && await enforceClean(opts)
+  const doGit = gitTagVersion && isGitDir && await enforceClean(opts)
 
   const runScript = ignoreScripts ? () => {} : runner({
     ...opts,


### PR DESCRIPTION
we were passing the option in but ignoring it, this change makes it so we don't ignore it and actually skip committing and tagging the changes when `gitTagVersion` is `false`

note: it may _appear_ that this would be a semver-major, but `lib/index.js` defaults `gitTagVersion` to `true` so the tests having `gitTagVersion: true` added to them was only necessary because the tests skip the setting of defaults.

For https://github.com/npm/cli/issues/1973
