### PR TITLE
Retrieve unannotated Git tags too

### DIFF
--- a/lib/retrieve-tag.js
+++ b/lib/retrieve-tag.js
@@ -2,7 +2,9 @@ const {spawn} = require('@npmcli/git')
 const semver = require('semver')
 
 module.exports = async opts => {
-  const tag = (await spawn(['describe', '--tags', '--abbrev=0'], opts)).stdout.trim()
+  const tag = (await spawn(['describe', '--tags', '--abbrev=0',  '--match=\'*.*.*\''], opts)).stdout.trim()
+  // XXX this "v?" is either wrong or spurious, because `tagVersionPrefix` can
+  // be anything
   const match = tag.match(/v?(\d+\.\d+\.\d+(?:[-+].+)?)/)
   const ver = match && semver.clean(match[1], { loose: true })
   if (ver)

--- a/lib/retrieve-tag.js
+++ b/lib/retrieve-tag.js
@@ -2,7 +2,7 @@ const {spawn} = require('@npmcli/git')
 const semver = require('semver')
 
 module.exports = async opts => {
-  const tag = (await spawn(['describe', '--abbrev=0'], opts)).stdout.trim()
+  const tag = (await spawn(['describe', '--tags', '--abbrev=0'], opts)).stdout.trim()
   const match = tag.match(/v?(\d+\.\d+\.\d+(?:[-+].+)?)/)
   const ver = match && semver.clean(match[1], { loose: true })
   if (ver)


### PR DESCRIPTION
Unannotated Git tags should be considered alongside annotated tags when
retrieving a version from Git.

Compared to annotated tags, unannotated tags do not contain a distinct
commit message or metadata, but neither are needed to retrieve version name.

See: https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---tags


## References
Cherry-pick from https://github.com/npm/libnpmversion/pull/5