### PR TITLE
fix(retrieve-tag): pass match in a way git accepts

### DIFF
--- a/lib/retrieve-tag.js
+++ b/lib/retrieve-tag.js
@@ -2,7 +2,7 @@ const { spawn } = require('@npmcli/git')
 const semver = require('semver')
 
 module.exports = async opts => {
-  const tag = (await spawn(['describe', '--tags', '--abbrev=0', '--match=\'*.*.*\''], opts)).stdout.trim()
+  const tag = (await spawn(['describe', '--tags', '--abbrev=0', '--match=*.*.*'], opts)).stdout.trim()
   const ver = semver.coerce(tag, { loose: true })
   if (ver) {
     return ver.version


### PR DESCRIPTION
The old way worked in our tests, but some other versions of git would
error out here.

## References
Closes https://github.com/npm/libnpmversion/issues/15