### PR TITLE
fix: drop node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,80 +1,52 @@
----
-################################################################################
-# Template - Node CI
-#
-# Description:
-#   This contains the basic information to: install dependencies, run tests,
-#   get coverage, and run linting on a nodejs project. This template will run
-#   over the MxN matrix of all operating systems, and all current LTS versions
-#   of NodeJS.
-#
-# Dependencies:
-#   This template assumes that your project is using the `tap` module for
-#   testing. If you're not using this module, then the step that runs your
-#   coverage will need to be adjusted.
-#
-################################################################################
-name: Node CI
+name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - latest
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: npm
+      - run: npm i --prefer-online -g npm@latest
+      - run: npm ci
+      - run: npm run lint
+
+  test:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 13.x]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
-    runs-on: ${{ matrix.os }}
-
+        node-version: [12.13.0, 12.x, 14.15.0, 14.x, 16.x]
+        platform:
+        - os: ubuntu-latest
+          shell: bash
+        - os: macos-latest
+          shell: bash
+        - os: windows-latest
+          shell: bash
+        - os: windows-latest
+          shell: cmd
+        - os: windows-latest
+          shell: powershell
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
     steps:
-      # Checkout the repository
       - uses: actions/checkout@v2
-        # Installs the specific version of Node.js
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      ################################################################################
-      # Install Dependencies
-      #
-      #   ASSUMPTIONS:
-      #     - The project has a package-lock.json file
-      #
-      #   Simply run the tests for the project.
-      ################################################################################
-      - name: Install dependencies
-        run: npm ci
-
-      ################################################################################
-      # Run Testing
-      #
-      #   ASSUMPTIONS:
-      #     - The project has `tap` as a devDependency
-      #     - There is a script called "test" in the package.json
-      #
-      #   Simply run the tests for the project.
-      ################################################################################
-      - name: Run tests
-        run: npm test -- --no-coverage
-
-      ################################################################################
-      # Run coverage check
-      #
-      #   ASSUMPTIONS:
-      #     - The project has `tap` as a devDependency
-      #     - There is a script called "coverage" in the package.json
-      #
-      #   Coverage should only be posted once, we are choosing the latest LTS of
-      #   node, and ubuntu as the matrix point to post coverage from. We limit
-      #   to the 'push' event so that coverage ins't posted twice from the
-      #   pull-request event, and push event (line 3).
-      ################################################################################
-      - name: Run coverage report
-        if: github.event_name == 'push' && matrix.node-version == '12.x' && matrix.os == 'ubuntu-latest'
-        run: npm test
-        env:
-          # The environment variable name is leveraged by `tap`
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          cache: npm
+      - run: npm i --prefer-online -g npm@latest
+      - run: npm ci
+      - run: npm test --ignore-scripts
+      - run: npm ls -a

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "json-parse-even-better-errors": "^2.3.1",
     "semver": "^7.3.5",
     "stringify-package": "^1.0.1"
+  },
+  "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: this moves our `engines` support and testing matrix
forward to node12 LTS and above.
